### PR TITLE
changed getters and triangulate() to return const reference

### DIFF
--- a/delaunay.cpp
+++ b/delaunay.cpp
@@ -1,6 +1,7 @@
 #include "delaunay.h"
+#include <algorithm>
 
-std::vector<Triangle> Delaunay::triangulate(std::vector<Vec2f> &vertices)
+const std::vector<Triangle>& Delaunay::triangulate(std::vector<Vec2f> &vertices)
 {
 	// Determinate the super triangle
 	float minX = vertices[0].x;

--- a/delaunay.h
+++ b/delaunay.h
@@ -5,20 +5,15 @@
 #include "triangle.h"
 
 #include <vector>
-#include <memory>
-#include <iostream>
-#include <algorithm>
-#include <iterator>
-#include <cmath>
 
 typedef Vector2<float> Vec2f;
 
 class Delaunay
 {
 	public:
-		std::vector<Triangle> triangulate(std::vector<Vec2f> &vertices);
-		std::vector<Triangle> getTriangles() { return _triangles; };
-		std::vector<Edge> getEdges() { return _edges; };
+		const std::vector<Triangle>& triangulate(std::vector<Vec2f> &vertices);
+		const std::vector<Triangle>& getTriangles() const { return _triangles; };
+		const std::vector<Edge>& getEdges() const { return _edges; };
 
 	private:
 		std::vector<Triangle> _triangles;


### PR DESCRIPTION
Returning by copy brings an unnecessary performance penalty since _triangles and _egdes are both class members therefore RVO cannot be used.