### PR TITLE
minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,22 @@ CXXFLAGS = -std=c++11 -Wall -Wextra -Wfatal-errors -pedantic -w -Winline -fno-rt
 all: $(EXE)
 
 $(EXE): dir main.o delaunay.o triangle.o edge.o vector2.o
-	$(CXX) $(CXXFLAGS) -o $(EXE) $(OBJ)
+	$(CXX) -o $(EXE) $(OBJ) $(CXXFLAGS)
 
 main.o:main.cpp
-	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$@ -c $<
+	$(CXX) -o $(BUILD_DIR)/$@ -c $< $(CXXFLAGS)
 
 delaunay.o: delaunay.cpp	
-	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$@ -c $<
+	$(CXX) -o $(BUILD_DIR)/$@ -c $< $(CXXFLAGS)
 
 triangle.o: triangle.cpp
-	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$@ -c $<
+	$(CXX) -o $(BUILD_DIR)/$@ -c $< $(CXXFLAGS)
 
 edge.o: edge.h 
-	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$@ -c $<
+	$(CXX) -o $(BUILD_DIR)/$@ -c $< $(CXXFLAGS)
 
 vector2.o: vector2.h
-	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$@ -c $<
+	$(CXX) -o $(BUILD_DIR)/$@ -c $< $(CXXFLAGS)
 
 dir:
 	mkdir -p $(BUILD_DIR)

--- a/delaunay.h
+++ b/delaunay.h
@@ -6,8 +6,6 @@
 
 #include <vector>
 
-typedef Vector2<float> Vec2f;
-
 class Delaunay
 {
 	public:

--- a/main.cpp
+++ b/main.cpp
@@ -12,8 +12,6 @@
 #include "triangle.h"
 #include "delaunay.h"
 
-typedef Vector2<float> Vec2f;
-
 float RandomFloat(float a, float b) {
     float random = ((float) rand()) / (float) RAND_MAX;
     float diff = b - a;

--- a/triangle.h
+++ b/triangle.h
@@ -4,8 +4,6 @@
 #include "vector2.h"
 #include "edge.h"
 
-typedef Vector2<float> Vec2f;
-
 class Triangle
 {
 	public:


### PR DESCRIPTION
building failed because of dependency issues.  I got the following errors:

```
build/main.o: In function `main':
.../Bl4ck0ne/delaunay-triangulation/main.cpp:56: undefined reference to `sf::String::String(char const*, std::locale const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:56: undefined reference to `sf::VideoMode::VideoMode(unsigned int, unsigned int, unsigned int)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:56: undefined reference to `sf::RenderWindow::RenderWindow(sf::VideoMode, sf::String const&, unsigned int, sf::ContextSettings const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:62: undefined reference to `sf::RectangleShape::RectangleShape(sf::Vector2<float> const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:63: undefined reference to `sf::Transformable::setPosition(float, float)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:70: undefined reference to `sf::Vertex::Vertex(sf::Vector2<float> const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:70: undefined reference to `sf::Vertex::Vertex(sf::Vector2<float> const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:76: undefined reference to `sf::Window::isOpen() const'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:79: undefined reference to `sf::Window::pollEvent(sf::Event&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:82: undefined reference to `sf::Window::close()'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:85: undefined reference to `sf::Color::Color(unsigned char, unsigned char, unsigned char, unsigned char)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:85: undefined reference to `sf::RenderTarget::clear(sf::Color const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:89: undefined reference to `sf::RenderStates::Default'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:89: undefined reference to `sf::RenderTarget::draw(sf::Drawable const&, sf::RenderStates const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:94: undefined reference to `sf::RenderStates::Default'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:94: undefined reference to `sf::RenderTarget::draw(sf::Vertex const*, unsigned long, sf::PrimitiveType, sf::RenderStates const&)'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:97: undefined reference to `sf::Window::display()'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:56: undefined reference to `sf::RenderWindow::~RenderWindow()'
.../Bl4ck0ne/delaunay-triangulation/main.cpp:56: undefined reference to `sf::RenderWindow::~RenderWindow()'
collect2: error: ld returned 1 exit status
Makefile:14: recipe for target 'delaunay' failed
make: *** [delaunay] Error 1
```

Putting the `$(CXXFLAGS)` at the end of the `g++` compile line worked for me and now it compiles and runs fine.

I also consolidated the `Vec2f` type definitions so they're only created once in the `edge.h` file.