### PR TITLE
Increase performance by removing transient containers and O(N^2) sear…

### DIFF
--- a/delaunay.h
+++ b/delaunay.h
@@ -55,7 +55,6 @@ class Delaunay
 				//std::cout << "Traitement du point " << *p << std::endl;
 				//std::cout << "_triangles contains " << _triangles.size() << " elements" << std::endl;	
 
-				std::vector<TriangleType> badTriangles;
 				std::vector<EdgeType> polygon;
 
 				for(auto t = begin(_triangles); t != end(_triangles); t++)
@@ -65,7 +64,7 @@ class Delaunay
 					if(t->circumCircleContains(*p))
 					{
 						//std::cout << "Pushing bad triangle " << *t << std::endl;
-						badTriangles.push_back(*t);
+						t->isBad = true;
 						polygon.push_back(t->e1);	
 						polygon.push_back(t->e2);	
 						polygon.push_back(t->e3);	
@@ -76,19 +75,10 @@ class Delaunay
 					}
 				}
 
-				_triangles.erase(std::remove_if(begin(_triangles), end(_triangles), [badTriangles](TriangleType &t){
-					for(auto bt = begin(badTriangles); bt != end(badTriangles); bt++)
-					{	
-						if(*bt == t)
-						{
-							//std::cout << "Removing bad triangle " << std::endl << *bt << " from _triangles" << std::endl;
-							return true;		
-						}
-					}
-					return false;
+				_triangles.erase(std::remove_if(begin(_triangles), end(_triangles), [](TriangleType &t){
+					return t.isBad;
 				}), end(_triangles));
 
-				std::vector<EdgeType> badEdges;
 				for(auto e1 = begin(polygon); e1 != end(polygon); e1++)
 				{
 					for(auto e2 = begin(polygon); e2 != end(polygon); e2++)
@@ -98,19 +88,14 @@ class Delaunay
 						
 						if(*e1 == *e2)
 						{
-							badEdges.push_back(*e1);	
-							badEdges.push_back(*e2);	
+							e1->isBad = true;
+							e2->isBad = true;	
 						}
 					}
 				}
 
-				polygon.erase(std::remove_if(begin(polygon), end(polygon), [badEdges](EdgeType &e){
-					for(auto it = begin(badEdges); it != end(badEdges); it++)
-					{
-						if(*it == e)
-							return true;
-					}
-					return false;
+				polygon.erase(std::remove_if(begin(polygon), end(polygon), [](EdgeType &e){
+					return e.isBad;
 				}), end(polygon));
 
 				for(auto e = begin(polygon); e != end(polygon); e++)

--- a/edge.h
+++ b/edge.h
@@ -9,11 +9,13 @@ class Edge
 	public:
 		using VertexType = Vector2<T>;
 		
-		Edge(const VertexType &p1, const VertexType &p2) : p1(p1), p2(p2) {};
-		Edge(const Edge &e) : p1(e.p1), p2(e.p2) {};
+		Edge(const VertexType &p1, const VertexType &p2) : p1(p1), p2(p2), isBad(false) {};
+		Edge(const Edge &e) : p1(e.p1), p2(e.p2), isBad(false) {};
 
 		VertexType p1;
 		VertexType p2;
+
+		bool isBad;
 };
 
 template <class T>

--- a/triangle.h
+++ b/triangle.h
@@ -16,7 +16,7 @@ class Triangle
 		
 		Triangle(const VertexType &_p1, const VertexType &_p2, const VertexType &_p3)
 		:	p1(_p1), p2(_p2), p3(_p3),
-			e1(_p1, _p2), e2(_p2, _p3), e3(_p3, _p1)
+			e1(_p1, _p2), e2(_p2, _p3), e3(_p3, _p1), isBad(false)
 		{}
 	
 		bool containsVertex(const VertexType &v)
@@ -44,6 +44,7 @@ class Triangle
 		EdgeType e1;				
 		EdgeType e2;
 		EdgeType e3;
+		bool isBad;
 };
 
 template <class T>


### PR DESCRIPTION
Increase performance by removing transient containers and O(N^2) searches.

Further speedups include using indexed primitives into a constant vertex cache.  However, this produces diminishing returns (except for very large triangulations).