### PR TITLE
Setup GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CI
+on: [push, pull_request]
+jobs:
+
+  macos:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install homebrew packages
+      run: brew install cmake git meson pkg-config
+    - name: Install Catch2
+      run: git clone -b v2.11.3 https://github.com/catchorg/Catch2.git &&
+        cd Catch2 &&
+        cmake -Bbuild -H. -DBUILD_TESTING=OFF &&
+        cmake --build build/ --target install
+    - run: meson build
+    - run: ninja -C build
+    - run: ./build/tests --durations yes
+
+  ubuntu-1910_gcc:
+    runs-on: ubuntu-18.04
+    container:
+      image: ubuntu:19.10
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install APT packages
+      run: apt-get update && apt-get install -y
+        cmake g++ git libsfml-dev meson ninja-build pkg-config
+    - name: Install Catch2
+      run: git clone -b v2.11.3 https://github.com/catchorg/Catch2.git &&
+        cd Catch2 &&
+        cmake -Bbuild -H. -DBUILD_TESTING=OFF &&
+        cmake --build build/ --target install
+    - run: meson build
+    - run: ninja -C build
+    - run: ./build/tests --durations yes


### PR DESCRIPTION
I noticed that since the last time I used this library, many things have changed - even CI was removed :scream: I don't know why this was done, but maybe you are interested in enabling it again? If yes: using GitHub Actions is simple, does not need any registration on 3rd-party services, and works well, so I quickly added one job for Ubuntu 19.10 and one for macOS.

Problems so far:
- On macOS the example does not compile successfully, so I did not install the SFML library. Here the build output: 
  ```
  [4/10] Compiling C++ object 'example@exe/example_main.cpp.o'.
  FAILED: example@exe/example_main.cpp.o 
  c++ -Iexample@exe -I. -I.. -I../include -I/usr/local/opt/freetype/include/freetype2 -I/usr/local/Cellar/sfml/2.5.1/include -Xclang -fcolor-diagnostics -pipe -Wall -Winvalid-pch -Wnon-virtual-dtor -Wextra -Wpedantic -Werror -std=c++17 -g -Wshadow -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wconversion -Wsign-conversion -Wno-format-nonliteral -Wfatal-errors -MD -MQ 'example@exe/example_main.cpp.o' -MF 'example@exe/example_main.cpp.o.d' -o 'example@exe/example_main.cpp.o' -c ../example/main.cpp
  In file included from ../example/main.cpp:9:
  In file included from /usr/local/Cellar/sfml/2.5.1/include/SFML/Graphics.hpp:32:
  In file included from /usr/local/Cellar/sfml/2.5.1/include/SFML/Window.hpp:32:
  In file included from /usr/local/Cellar/sfml/2.5.1/include/SFML/System.hpp:42:
  In file included from /usr/local/Cellar/sfml/2.5.1/include/SFML/System/String.hpp:32:
  In file included from /usr/local/Cellar/sfml/2.5.1/include/SFML/System/Utf.hpp:731:
  /usr/local/Cellar/sfml/2.5.1/include/SFML/System/Utf.inl:296:64: fatal error: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
                  output = static_cast<Uint32>(((first - 0xD800) << 10) + (second - 0xDC00) + 0x0010000);
                                                ~~~~~~~~~~~~~~~~~^~~~~  ~
  1 error generated.
  ```
- I could not add a job for the latest Ubuntu LTS (18.04) because of this issue:
  ```
  meson.build:1:0: ERROR: Meson version is 0.45.1 but project requires >=0.50.0.
  ```

Probably the CI on this repository will run only *after* merging this, but you can see how it looks in my fork: https://github.com/LibrePCB/delaunay-triangulation/actions/runs/80208642

Please let me know if I should change something. And feel free to close the PR if you don't like it :wink: