### PR TITLE
Move library into namespace "dt"

### DIFF
--- a/dt/delaunay.cpp
+++ b/dt/delaunay.cpp
@@ -1,5 +1,7 @@
 #include "delaunay.h"
 
+namespace dt {
+
 template<typename T>
 const std::vector<typename Delaunay<T>::TriangleType>&
 Delaunay<T>::triangulate(std::vector<VertexType> &vertices)
@@ -111,3 +113,5 @@ Delaunay<T>::getVertices() const
 
 template class Delaunay<float>;
 template class Delaunay<double>;
+
+} // namespace dt

--- a/dt/edge.cpp
+++ b/dt/edge.cpp
@@ -1,5 +1,7 @@
 #include "edge.h"
 
+namespace dt {
+
 template<typename T>
 Edge<T>::Edge(const VertexType &v1, const VertexType &v2) :
 	v(&v1), w(&v2)
@@ -22,3 +24,5 @@ operator <<(std::ostream &str, const Edge<U> &e)
 
 template struct Edge<float>;
 template struct Edge<double>;
+
+} // namespace dt

--- a/dt/triangle.cpp
+++ b/dt/triangle.cpp
@@ -1,5 +1,7 @@
 #include "triangle.h"
 
+namespace dt {
+
 template<typename T>
 Triangle<T>::Triangle(const VertexType &v1, const VertexType &v2, const VertexType &v3) :
 	a(&v1), b(&v2), c(&v3), isBad(false)
@@ -58,3 +60,5 @@ operator <<(std::ostream &str, const Triangle<U> &t)
 
 template struct Triangle<float>;
 template struct Triangle<double>;
+
+} // namespace dt

--- a/dt/vector2.cpp
+++ b/dt/vector2.cpp
@@ -1,5 +1,7 @@
 #include "vector2.h"
 
+namespace dt {
+
 template<typename T>
 Vector2<T>::Vector2(const T vx, const T vy) :
 	x(vx), y(vy)
@@ -49,3 +51,5 @@ operator <<(std::ostream &str, const Vector2<U> &v)
 
 template struct Vector2<float>;
 template struct Vector2<double>;
+
+} // namespace dt

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -26,20 +26,20 @@ int main(int argc, char * argv[])
 
 	std::cout << "Generating " << numberPoints << " random points" << std::endl;
 
-	std::vector<Vector2<double>> points;
+	std::vector<dt::Vector2<double>> points;
 	for(int i = 0; i < numberPoints; ++i) {
-		points.push_back(Vector2<double>{dist_w(eng), dist_h(eng)});
+		points.push_back(dt::Vector2<double>{dist_w(eng), dist_h(eng)});
 	}
 
-	Delaunay<double> triangulation;
+	dt::Delaunay<double> triangulation;
 	const auto start = std::chrono::high_resolution_clock::now();
-	const std::vector<Triangle<double>> triangles = triangulation.triangulate(points);
+	const std::vector<dt::Triangle<double>> triangles = triangulation.triangulate(points);
 	const auto end = std::chrono::high_resolution_clock::now();
 	const std::chrono::duration<double> diff = end - start;
 
 	std::cout << triangles.size() << " triangles generated in " << diff.count()
 			<< "s\n";
-	const std::vector<Edge<double>> edges = triangulation.getEdges();
+	const std::vector<dt::Edge<double>> edges = triangulation.getEdges();
 
 	// SFML window
 	sf::RenderWindow window(sf::VideoMode(800, 600), "Delaunay triangulation");

--- a/include/delaunay.h
+++ b/include/delaunay.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <algorithm>
 
+namespace dt {
+
 template<typename T>
 class Delaunay
 {
@@ -37,5 +39,7 @@ public:
 	Delaunay& operator=(const Delaunay&) = delete;
 	Delaunay& operator=(Delaunay&&) = delete;
 };
+
+} // namespace dt
 
 #endif

--- a/include/edge.h
+++ b/include/edge.h
@@ -3,6 +3,8 @@
 
 #include "vector2.h"
 
+namespace dt {
+
 template<typename T>
 struct Edge
 {
@@ -36,6 +38,8 @@ almost_equal(const Edge<T> &e1, const Edge<T> &e2)
 	return	(almost_equal(*e1.v, *e2.v) && almost_equal(*e1.w, *e2.w)) ||
 			(almost_equal(*e1.v, *e2.w) && almost_equal(*e1.w, *e2.v));
 }
+
+} // namespace dt
 
 #endif
 

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -4,6 +4,8 @@
 #include <math.h>
 #include <limits>
 
+namespace dt {
+
 /**
  * @brief use of machine epsilon to compare floating-point values for equality
  * http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
@@ -34,5 +36,7 @@ T half(const T x)
 	}
 	static_assert(true, "Must be floating-point type");
 }
+
+} // namespace dt
 
 #endif

--- a/include/triangle.h
+++ b/include/triangle.h
@@ -5,6 +5,8 @@
 #include "vector2.h"
 #include "edge.h"
 
+namespace dt {
+
 template<typename T>
 struct Triangle
 {
@@ -43,5 +45,7 @@ bool almost_equal(const Triangle<T> &t1, const Triangle<T> &t2)
 			(almost_equal(*t1.b , *t2.a) || almost_equal(*t1.b , *t2.b) || almost_equal(*t1.b , *t2.c)) &&
 			(almost_equal(*t1.c , *t2.a) || almost_equal(*t1.c , *t2.b) || almost_equal(*t1.c , *t2.c));
 }
+
+} // namespace dt
 
 #endif

--- a/include/vector2.h
+++ b/include/vector2.h
@@ -7,6 +7,8 @@
 #include <cmath>
 #include <type_traits>
 
+namespace dt {
+
 template<typename T>
 struct Vector2
 {
@@ -38,5 +40,7 @@ bool almost_equal(const Vector2<T> &v1, const Vector2<T> &v2)
 {
 	return almost_equal(v1.x, v2.x) && almost_equal(v1.y, v2.y);
 }
+
+} // namespace dt
 
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -3,6 +3,8 @@
 #include <catch2/catch.hpp>
 #include "delaunay.h"
 
+namespace dt {
+
 TEST_CASE( "Delaunay triangulation should be able to triangulate 3 points as double", "[DelaunayTest]" ) {
 	std::vector<Vector2<double>> points;
 	points.push_back(Vector2<double>{0.0, 0.0});
@@ -39,4 +41,6 @@ TEST_CASE("Delaunay triangulation should be able to handle 10000 points as doubl
 	REQUIRE(points.size() == nb_pts);
 	Delaunay<double> triangulation;
 	const std::vector<Triangle<double>> triangles = triangulation.triangulate(points);
+}
+
 }


### PR DESCRIPTION
To avoid clutter up the global namespace -> reduce the risk of name conflicts. I called the namespace "dt" because the source directory is also named like that, but of course I could change the namespace if you prefer a different name :slightly_smiling_face: 