### PR TITLE
Restore C++11 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,25 @@ jobs:
     - run: meson build
     - run: ninja -C build
     - run: ./build/tests --durations yes
+
+  ubuntu-1910_clang_cpp11:
+    runs-on: ubuntu-18.04
+    container:
+      image: ubuntu:19.10
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install APT packages
+      run: apt-get update && apt-get install -y
+        cmake clang git libsfml-dev meson ninja-build pkg-config
+    - name: Install Catch2
+      run: git clone -b v2.11.3 https://github.com/catchorg/Catch2.git &&
+        cd Catch2 &&
+        cmake -Bbuild -H. -DBUILD_TESTING=OFF &&
+        cmake --build build/ --target install
+    - run: meson build
+    - run: meson configure -Dcpp_std=c++11 build
+    - run: ninja -C build
+    - run: ./build/tests --durations yes

--- a/dt/delaunay.cpp
+++ b/dt/delaunay.cpp
@@ -26,8 +26,8 @@ Delaunay<T>::triangulate(std::vector<VertexType> &vertices)
 	const T dx = maxX - minX;
 	const T dy = maxY - minY;
 	const T deltaMax = std::max(dx, dy);
-	const T midx = half(minX + maxX);
-	const T midy = half(minY + maxY);
+	const T midx = (minX + maxX) / 2;
+	const T midy = (minY + maxY) / 2;
 
 	const VertexType p1(midx - 20 * deltaMax, midy - deltaMax);
 	const VertexType p2(midx, midy + 20 * deltaMax);
@@ -45,9 +45,9 @@ Delaunay<T>::triangulate(std::vector<VertexType> &vertices)
 			if(t.circumCircleContains(*p))
 			{
 				t.isBad = true;
-				polygon.push_back(Edge{*t.a, *t.b});
-				polygon.push_back(Edge{*t.b, *t.c});
-				polygon.push_back(Edge{*t.c, *t.a});
+				polygon.push_back(Edge<T>{*t.a, *t.b});
+				polygon.push_back(Edge<T>{*t.b, *t.c});
+				polygon.push_back(Edge<T>{*t.c, *t.a});
 			}
 		}
 
@@ -82,9 +82,9 @@ Delaunay<T>::triangulate(std::vector<VertexType> &vertices)
 
 	for(const auto t : _triangles)
 	{
-		_edges.push_back(Edge{*t.a, *t.b});
-		_edges.push_back(Edge{*t.b, *t.c});
-		_edges.push_back(Edge{*t.c, *t.a});
+		_edges.push_back(Edge<T>{*t.a, *t.b});
+		_edges.push_back(Edge<T>{*t.b, *t.c});
+		_edges.push_back(Edge<T>{*t.c, *t.a});
 	}
 
 	return _triangles;

--- a/dt/triangle.cpp
+++ b/dt/triangle.cpp
@@ -33,7 +33,7 @@ Triangle<T>::circumCircleContains(const VertexType &v) const
 	const T circum_x = (ab * (cy - by) + cd * (ay - cy) + ef * (by - ay)) / (ax * (cy - by) + bx * (ay - cy) + cx * (by - ay));
 	const T circum_y = (ab * (cx - bx) + cd * (ax - cx) + ef * (bx - ax)) / (ay * (cx - bx) + by * (ax - cx) + cy * (bx - ax));
 
-	const VertexType circum(half(circum_x), half(circum_y));
+	const VertexType circum(circum_x / 2, circum_y / 2);
 	const T circum_radius = a->dist2(circum);
 	const T dist = v.dist2(circum);
 	return dist <= circum_radius;

--- a/dt/vector2.cpp
+++ b/dt/vector2.cpp
@@ -16,16 +16,18 @@ Vector2<T>::dist2(const Vector2<T> &v) const
 	return dx * dx + dy * dy;
 }
 
-template<typename T>
-T
-Vector2<T>::dist(const Vector2<T> &v) const
+template<>
+float
+Vector2<float>::dist(const Vector2<float> &v) const
 {
-	if constexpr (std::is_same_v<T, float>) {
-		return hypotf(x - v.x, y - v.y);
-	} else if constexpr (std::is_same_v<T, double>) {
-		return hypot(x - v.x, y - v.y);
-	}
-	static_assert(true, "Must be floating-point type");
+	return hypotf(x - v.x, y - v.y);
+}
+
+template<>
+double
+Vector2<double>::dist(const Vector2<double> &v) const
+{
+	return hypot(x - v.x, y - v.y);
 }
 
 template<typename T>

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char * argv[])
 					static_cast<float>(e.w->x + 2.),
 					static_cast<float>(e.w->y + 2.))),
 		}};
-		window.draw(std::data(line), 2, sf::Lines);
+		window.draw(line.data(), 2, sf::Lines);
 	}
 
 	window.display();

--- a/include/delaunay.h
+++ b/include/delaunay.h
@@ -18,7 +18,7 @@ class Delaunay
 	using EdgeType = Edge<Type>;
 	using TriangleType = Triangle<Type>;
 
-	static_assert(std::is_floating_point_v<Delaunay<T>::Type>,
+	static_assert(std::is_floating_point<Delaunay<T>::Type>::value,
 		"Type must be floating-point");
 
 	std::vector<TriangleType> _triangles;

--- a/include/edge.h
+++ b/include/edge.h
@@ -27,7 +27,7 @@ struct Edge
 	const VertexType *w;
 	bool isBad = false;
 
-	static_assert(std::is_floating_point_v<Edge<T>::Type>,
+	static_assert(std::is_floating_point<Edge<T>::Type>::value,
 		"Type must be floating-point");
 };
 
@@ -42,4 +42,3 @@ almost_equal(const Edge<T> &e1, const Edge<T> &e2)
 } // namespace dt
 
 #endif
-

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <limits>
+#include <type_traits>
 
 namespace dt {
 
@@ -11,30 +12,19 @@ namespace dt {
  * http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
  */
 template<class T>
-typename std::enable_if<std::is_floating_point_v<T>, bool>::type
+typename std::enable_if<std::is_same<T, float>::value, bool>::type
 almost_equal(T x, T y, int ulp=2)
 {
-	// the machine epsilon has to be scaled to the magnitude of the values used
-	// and multiplied by the desired precision in ULPs (units in the last place)
-	// unless the result is subnormal
-	if constexpr (std::is_same_v<T, float>) {
-		return fabsf(x-y) <= std::numeric_limits<float>::epsilon() * fabsf(x+y) * static_cast<float>(ulp)
-				|| fabsf(x-y) < std::numeric_limits<float>::min();
-	} else if constexpr (std::is_same_v<T, double>) {
-		return fabs(x-y) <= std::numeric_limits<double>::epsilon() * fabs(x+y) * static_cast<double>(ulp)
-				|| fabs(x-y) < std::numeric_limits<double>::min();
-	}
+	return fabsf(x-y) <= std::numeric_limits<float>::epsilon() * fabsf(x+y) * static_cast<float>(ulp)
+        	|| fabsf(x-y) < std::numeric_limits<float>::min();
 }
 
-template<typename T>
-T half(const T x)
+template<class T>
+typename std::enable_if<std::is_same<T, double>::value, bool>::type
+almost_equal(T x, T y, int ulp=2)
 {
-	if constexpr (std::is_same_v<T, float>) {
-		return 0.5f * x;
-	} else if constexpr (std::is_same_v<T, double>) {
-		return 0.5 * x;
-	}
-	static_assert(true, "Must be floating-point type");
+	return fabs(x-y) <= std::numeric_limits<double>::epsilon() * fabs(x+y) * static_cast<double>(ulp)
+	    	|| fabs(x-y) < std::numeric_limits<double>::min();
 }
 
 } // namespace dt

--- a/include/triangle.h
+++ b/include/triangle.h
@@ -34,7 +34,7 @@ struct Triangle
 	const VertexType *c;
 	bool isBad = false;
 
-	static_assert(std::is_floating_point_v<Triangle<T>::Type>,
+	static_assert(std::is_floating_point<Triangle<T>::Type>::value,
 		"Type must be floating-point");
 };
 

--- a/include/vector2.h
+++ b/include/vector2.h
@@ -31,7 +31,7 @@ struct Vector2
 	T x;
 	T y;
 
-	static_assert(std::is_floating_point_v<Vector2<T>::Type>,
+	static_assert(std::is_floating_point<Vector2<T>::Type>::value,
 		"Type must be floating-point");
 };
 


### PR DESCRIPTION
This PR makes sure that the library can also be compiled with C++11 and with Clang in addition to GCC. Of course C++17 is still supported.

Some notes:
- I simplified the `almost_equal()` function since the way it was done did not work with C++11, and IMHO it was more complicated than needed. When using `std::fabs()` from `<cmath>` instead of `fabs()`/`fabsf()` from `math.h`, the function is overloaded for both `float` and `double`, so you don't have to care about it - you will automatically get the correct one, depending on the passed parameter type.
- Same applies to the `Vector2::dist()` function -> Use `std::hypot` instead of `hypot()` and `hypotf()`.
- The same applies to the `half()` function, but I think this function is not needed at all and thus I removed it. Or why don't you simply use `my_float / 2` to half a floating point number? The compiler will automatically cast the integer `2` to the same floating point type as `my_float`, so it should do exactly the same as multiplying with `0.5` resp. `0.5f`, but it is much simpler.